### PR TITLE
Migrate coords to `pink.cozydev`

### DIFF
--- a/benchmarks/src/main/scala/textmogrify/LuceneStreamingBenchmark.scala
+++ b/benchmarks/src/main/scala/textmogrify/LuceneStreamingBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/src/main/scala/textmogrify/LuceneTokenizationBenchmark.scala
+++ b/benchmarks/src/main/scala/textmogrify/LuceneTokenizationBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
 ThisBuild / tlBaseVersion := "0.0" // your current series x.y
 
-ThisBuild / organization := "io.pig"
-ThisBuild / organizationName := "Pig.io"
+ThisBuild / organization := "pink.cozydev"
+ThisBuild / organizationName := "CozyDev"
 ThisBuild / startYear := Some(2022)
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ To use the latest version, include the following in your `build.sbt`:
 
 ```scala
 libraryDependencies ++= Seq(
-  "io.pig" %% "textmogrify" % "@VERSION@"
+  "pink.cozydev" %% "textmogrify" % "@VERSION@"
 )
 ```
 
@@ -20,7 +20,7 @@ Currently the core functionality of textmogrify is implemented with [Lucene][luc
 
 ```scala
 libraryDependencies ++= Seq(
-  "io.pig" %% "textmogrify-lucene" % "@VERSION@"
+  "pink.cozydev" %% "textmogrify-lucene" % "@VERSION@"
 )
 ```
 

--- a/example/src/main/scala/textmogrify/LuceneStreaming.scala
+++ b/example/src/main/scala/textmogrify/LuceneStreaming.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/main/scala/textmogrify/MultiLingualPipeline.scala
+++ b/example/src/main/scala/textmogrify/MultiLingualPipeline.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/main/scala/textmogrify/Pipeline.scala
+++ b/example/src/main/scala/textmogrify/Pipeline.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lucene/src/main/scala/textmogrify/lucene/AnalyzerBuilder.scala
+++ b/lucene/src/main/scala/textmogrify/lucene/AnalyzerBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lucene/src/main/scala/textmogrify/lucene/AnalyzerPipe.scala
+++ b/lucene/src/main/scala/textmogrify/lucene/AnalyzerPipe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lucene/src/main/scala/textmogrify/lucene/AnalyzerResource.scala
+++ b/lucene/src/main/scala/textmogrify/lucene/AnalyzerResource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lucene/src/main/scala/textmogrify/lucene/Tokenizer.scala
+++ b/lucene/src/main/scala/textmogrify/lucene/Tokenizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lucene/src/test/scala/textmogrify/lucene/AnalyzerBuilderSuite.scala
+++ b/lucene/src/test/scala/textmogrify/lucene/AnalyzerBuilderSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lucene/src/test/scala/textmogrify/lucene/AnalyzerPipeSuite.scala
+++ b/lucene/src/test/scala/textmogrify/lucene/AnalyzerPipeSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lucene/src/test/scala/textmogrify/lucene/AnalyzerResourceSuite.scala
+++ b/lucene/src/test/scala/textmogrify/lucene/AnalyzerResourceSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pig.io
+ * Copyright 2022 CozyDev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates our coordinates to `pink.cozydev` and changes all the copyright headers to match.
I will update the README once a new release is cut.